### PR TITLE
Adding network recovery routine to update script

### DIFF
--- a/firmware_setup.sh
+++ b/firmware_setup.sh
@@ -133,6 +133,7 @@ apt-get purge docker docker-engine docker.io containerd runc -y
 apt autoremove -y
 apt-get install --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" screen ipcalc macchanger openvpn lldpd dnsmasq libffi-dev libssl-dev python3 python3-pip -y
 
+export CRYPTOGRAPHY_DONT_BUILD_RUST=1
 source "$HOME/.cargo/env"
 export PATH="$HOME/.cargo/bin:$PATH"
 

--- a/firmware_setup.sh
+++ b/firmware_setup.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+
+# curl -sSL ac5000setup.aiwell.no | bash
+
+touch /root/setup
+export DEBIAN_FRONTEND=noninteractive
+mkdir /root/storage
+
+#Expand storage
+resize2fs /dev/mmcblk0p3
+# Function to check if available storage space is larger than the provided argument (in MB)
+check_storage_space() {
+  local required_space=$1  # Required space in megabytes
+  local available_space=$(df -BM . | awk 'NR==2 {print $4}' | tr -d 'M')  # Available space in megabytes
+
+  if [ "$available_space" -ge "$required_space" ]; then
+    return 0  # Available space is larger or equal to the required space
+  else
+    return 1  # Available space is smaller than the required space
+  fi
+}
+
+check_storage_space 500
+
+if [ $? -eq 0 ]; then
+  echo "Det er nok lagringsplass på enheten."
+else
+  echo "Ikke nok lagringsplass."
+  echo "Sletter logger og prøver igjen."
+  rm /var/log/*.gz
+  rm /var/log/*.[1-9]
+  
+  check_storage_space 500
+
+  if [ $? -eq 0 ]; then
+    echo "Det er nok lagringsplass på enheten."
+  else
+    printf "p\nd\n3\nn\np\n3\n2785280\n\nN\nw\n" | fdisk /dev/mmcblk0
+    green='\033[0;32m'
+    clear='\033[0m'
+    printf "\n${green}Forsøker å utvide lagringsplassen. Systemet vil starte på nytt av seg selv${clear}!"
+    printf "\n${green}Kjør setup på nytt etter omstart${clear}!"
+    reboot
+    #
+  fi  
+fi
+
+apt-get update --allow-releaseinfo-change -y
+# Detect the platform (CM3 or CM4)
+platform=$(cat /proc/cpuinfo | grep "Hardware" | awk '{print $3}')
+
+# Define the default I2C bus number (CM3)
+i2c_bus=0
+setenv I2C_ADDRESS_EXCARD 0
+
+# If the platform is CM4, change the I2C bus number
+if [ "$platform" = "BCM2711" ]; then
+  i2c_bus=1
+  setenv I2C_ADDRESS_EXCARD 1
+fi
+
+# Define the I2C addresses to check (expressed without "0x" prefix)
+addresses=("20" "21" "22")
+#The previous line causes the error sh: 61: Syntax error: "(" unexpected
+
+# Function to check the presence of a board at an address
+check_board_presence() {
+  local address="$1"
+  i2cget -y "$i2c_bus" "0x$address" >/dev/null 2>&1
+  local exit_code=$?
+  if [ $exit_code -eq 0 ] || [ $exit_code -eq 1 ]; then
+    return 0  # Return 0 if i2cget returns 0 or 1
+  else
+    return $exit_code  # Return the actual exit code from i2cget
+  fi
+}
+
+# Loop to check each address
+for address in "${addresses[@]}"; do
+  if check_board_presence "$address"; then
+    echo "Board found at address $address"
+    case "$address" in
+      "20") setenv EX_CARD_1 4R ;;
+      "21") setenv EX_CARD_2 4R ;;
+      "22") setenv EX_CARD_3 4R ;;
+      *) echo "Unknown board at address 0x$address";;
+    esac
+  fi
+done
+
+# Run the firmware update command with a timeout
+run_techbase_update() {
+  local output
+  output=$(eval "$1")
+
+  if [ $? -eq 0 ]; then
+    if [[ "$output" == *"No updates available"* ]]; then
+      echo "Alt er oppdatert"
+    else
+      echo "Nye oppdateringer er installert. Fikser innstillinger."
+      cp dhcpcd.backup /etc/dhcpcd.conf
+    fi
+  else
+    echo "Klarte ikke å utføre kommandoen: $1"
+  fi
+}
+# Run the firmware update command with a timeout
+timeout 60 softmgr update firmware -b x500_5.10-beta
+RES=$?
+# Check if the previous command timed out
+if [ $RES -eq 124 ]; then
+  echo "The firmware update command timed out. Skipping the if-else block."
+else
+  # Check if the previous command succeeded
+  if [ $RES -eq 0 ]; then
+    # If successful, run the following commands    
+    run_techbase_update "timeout 30 softmgr update lib -b x500_5.10-beta"
+    run_techbase_update "timeout 30 softmgr update core -b x500_5.10-beta"
+  else
+    # If not successful, use standard update
+    run_techbase_update "timeout 120 softmgr update core -f yes"
+    run_techbase_update "timeout 120 softmgr update firmware -f yes"
+    run_techbase_update "timeout 30 softmgr update all"
+  fi
+fi
+
+#restore_settings -r
+#bash ex_card_configure.sh &
+curl -sSL https://raw.githubusercontent.com/aiwell-ac5000/ac5000/main/config.sh | sh
+
+apt-get purge docker docker-engine docker.io containerd runc -y
+
+apt autoremove -y
+apt-get install --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" screen ipcalc macchanger openvpn lldpd dnsmasq libffi-dev libssl-dev python3 python3-pip -y
+
+source "$HOME/.cargo/env"
+export PATH="$HOME/.cargo/bin:$PATH"
+
+user=user
+upwd=AiwellAC5000
+chpasswd <<EOF
+$user:$upwd
+EOF
+
+user=root
+upwd=Prod2001
+chpasswd <<EOF
+$user:$upwd
+EOF
+
+echo "interface=eth1" > /etc/dnsmasq.conf
+echo "bind-dynamic" >> /etc/dnsmasq.conf
+echo "domain-needed" >> /etc/dnsmasq.conf
+echo "bogus-priv" >> /etc/dnsmasq.conf
+echo "dhcp-range=192.168.0.100,192.168.0.200,255.255.255.0,12h" >> /etc/dnsmasq.conf
+echo "server=8.8.8.8" >> /etc/dnsmasq.conf
+
+wget https://raw.githubusercontent.com/aiwell-ac5000/ac5000/main/environment
+mv environment /etc/environment
+
+#sette hostname
+A=$(getenv HOST_MAC | cut -d'=' -f2 | cut -d':' -f1)
+
+if [ "$A" -eq 0 ]; then
+  A=18
+  B=83
+  C=C4
+  D=AC
+  E=50
+  F=00
+else
+  B=$(getenv HOST_MAC | cut -d'=' -f2 | cut -d':' -f2)
+  C=$(getenv HOST_MAC | cut -d'=' -f2 | cut -d':' -f3)
+  D=$(getenv HOST_MAC | cut -d'=' -f2 | cut -d':' -f4)
+  E=$(getenv HOST_MAC | cut -d'=' -f2 | cut -d':' -f5)
+  F=$(getenv HOST_MAC | cut -d'=' -f2 | cut -d':' -f6)  
+fi
+host=ac5000$A$B$C$D$E$F
+echo $host
+
+touch /etc/network/if-up.d/macchange
+echo "#!/bin/sh" > /etc/network/if-up.d/macchange
+echo 'if [ "$IFACE" = lo ]; then' >> /etc/network/if-up.d/macchange
+echo 'exit 0' >> /etc/network/if-up.d/macchange
+echo 'fi' >> /etc/network/if-up.d/macchange
+echo "/usr/bin/macchanger -m $A:$B:$C:$D:$E:$F eth0" >> /etc/network/if-up.d/macchange
+echo "/usr/bin/macchanger -m $A:$B:$C:$D:$E:$F eth1" >> /etc/network/if-up.d/macchange
+echo "getenv > /root/pipes/env" >> /etc/network/if-up.d/macchange
+chmod 755 /etc/network/if-up.d/macchange
+
+V=$(uname -r)
+ARCH = $(uname -m)
+DEBIAN_VERSION=$(grep "^VERSION=" /etc/os-release | cut -d '"' -f 2)
+echo "configure system description 'Aiwell AC5000 Debian $DEBIAN_VERSION Linux $V $ARCH'" > /etc/lldpd.conf
+systemctl restart lldpd
+systemctl enable lldpd
+
+wget https://raw.githubusercontent.com/aiwell-ac5000/ac5000/main/rsyslog
+mv rsyslog /etc/logrotate.d/rsyslog
+#The commands below run
+rm /var/log/*.gz
+rm /var/log/*.[1-9]
+# Why is the last command executed, and the first, but not those in the middle? 
+echo "timeout 240" >> /etc/dhcpcd.conf
+#fallback to static IP eth1
+echo "profile static_eth1" >> /etc/dhcpcd.conf
+echo "static ip_address=192.168.0.10/24" >> /etc/dhcpcd.conf
+echo "static routers=192.168.0.1" >> /etc/dhcpcd.conf
+echo "static domain_name_servers=8.8.8.8" >> /etc/dhcpcd.conf
+#Apply staic profile to eth1
+echo "interface eth1" >> /etc/dhcpcd.conf
+echo "fallback static_eth1" >> /etc/dhcpcd.conf
+echo "timeout 60" >> /etc/dhcpcd.conf
+
+cp /etc/dhcpcd.conf /etc/dhcpcd.base
+
+echo "1 rt2" >>  /etc/iproute2/rt_tables
+
+wget https://raw.githubusercontent.com/aiwell-ac5000/ac5000/main/dhcpcd.exit-hook
+mv dhcpcd.exit-hook /etc/dhcpcd.exit-hook
+
+ip addr list eth0 |grep "inet " |cut -d' ' -f6|cut -d/ -f1 > /root/pipes/ip
+
+systemctl daemon-reload
+timeout 20 service dhcpcd restart
+
+raspi-config nonint do_hostname $host 
+
+apt autoremove -y
+
+green='\033[0;32m'
+clear='\033[0m'
+printf "\n${green}Firmware Setup executed successfully. AC5000 IS SUPPOSED TO REBOOT. THIS IS NORMAL.${clear}!"
+printf "\n${green}Progammering ble korrekt utført. DET ER MENINGEN AT AC0500 SKAL STARTE PÅ NYTT AV SEG SELV ETTER PROGRAMMERING. DETTE ER HELT NORMALT${clear}!"
+
+reboot

--- a/firmware_update.sh
+++ b/firmware_update.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+
+# curl -sSL ac5000update.aiwell.no | bash
+
+# curl -sSL raw.githubusercontent.com/aiwell-ac5000/ac5000/update.sh | bash
+
+export DEBIAN_FRONTEND=noninteractive
+red='\033[0;31m'
+green='\033[0;32m'
+clear='\033[0m'
+
+rm /var/log/*.gz
+rm /var/log/*.[1-9]
+rm /var/log/*.old
+
+apt-get update --allow-releaseinfo-change -y
+
+#Backup av nettverk
+wget https://raw.githubusercontent.com/aiwell-ac5000/ac5000/main/dhcpcd.conf
+mv dhcpcd.conf /etc/dhcpcd.base
+cp /etc/dhcpcd.conf dhcpcd.backup
+run_techbase_update() {
+  local output
+  output=$(eval "$1")
+
+  if [ $? -eq 0 ]; then
+    if [[ "$output" == *"No updates available"* ]]; then
+      echo "Alt er oppdatert"
+    else
+      echo "Nye oppdateringer er installert. Fikser innstillinger."
+      #cp dhcpcd.backup /etc/dhcpcd.conf
+    fi
+  else
+    printf "\n${red}Klarte ikke å utføre kommandoen: $1${clear}!"
+  fi
+}
+# Run the firmware update command with a timeout
+timeout 120 softmgr update firmware -b x500_5.10-beta -f yes
+RES=$?
+# Check if the previous command timed out
+if [ $RES -eq 124 ]; then
+  printf "\n${red}Techbase-server svarer ikke.${clear}!"
+else
+  # Check if the previous command succeeded
+  if [ $RES -eq 0 ]; then
+    # If successful, run the following commands    
+    echo "Firmware oppdatert. Installerer øvrige oppdateringer."
+    run_techbase_update "timeout 120 softmgr update lib -b x500_5.10-beta -f yes"
+    run_techbase_update "timeout 120 softmgr update core -b x500_5.10-beta -f yes"
+  else
+    # If not successful, use standard update
+    run_techbase_update "timeout 120 softmgr update core -f yes"
+    run_techbase_update "timeout 120 softmgr update firmware -f yes"
+    run_techbase_update "timeout 120 softmgr update all"
+  fi
+fi
+cp dhcpcd.backup /etc/dhcpcd.conf
+platform=$(cat /proc/cpuinfo | grep "Hardware" | awk '{print $3}')
+
+# Define the default I2C bus number (CM3)
+i2c_bus=0
+setenv I2C_ADDRESS_EXCARD 0
+
+# If the platform is CM4, change the I2C bus number
+if [ "$platform" = "BCM2711" ]; then
+  i2c_bus=1
+  setenv I2C_ADDRESS_EXCARD 1
+fi
+
+# Define the I2C addresses to check (expressed without "0x" prefix)
+addresses=("20" "21" "22")
+#The previous line causes the error sh: 61: Syntax error: "(" unexpected
+
+# Function to check the presence of a board at an address
+check_board_presence() {
+  local address="$1"
+  i2cget -y "$i2c_bus" "0x$address" >/dev/null 2>&1
+  local exit_code=$?
+  if [ $exit_code -eq 0 ] || [ $exit_code -eq 1 ]; then
+    return 0  # Return 0 if i2cget returns 0 or 1
+  else
+    return $exit_code  # Return the actual exit code from i2cget
+  fi
+}
+
+# Loop to check each address
+for address in "${addresses[@]}"; do
+  if check_board_presence "$address"; then
+    echo "Board found at address $address"
+    case "$address" in
+      "20") setenv EX_CARD_1 4R ;;
+      "21") setenv EX_CARD_2 4R ;;
+      "22") setenv EX_CARD_3 4R ;;
+      *) echo "Unknown board at address 0x$address";;
+    esac
+  fi
+done
+
+export CRYPTOGRAPHY_DONT_BUILD_RUST=1
+source "$HOME/.cargo/env"
+export PATH="$HOME/.cargo/bin:$PATH"
+
+user=user
+upwd=AiwellAC5000
+chpasswd <<EOF
+$user:$upwd
+EOF
+
+user=root
+upwd=Prod2001
+chpasswd <<EOF
+$user:$upwd
+EOF
+
+echo "interface=eth1" > /etc/dnsmasq.conf
+echo "bind-dynamic" >> /etc/dnsmasq.conf
+echo "domain-needed" >> /etc/dnsmasq.conf
+echo "bogus-priv" >> /etc/dnsmasq.conf
+echo "dhcp-range=192.168.0.100,192.168.0.200,255.255.255.0,12h" >> /etc/dnsmasq.conf
+echo "server=8.8.8.8" >> /etc/dnsmasq.conf
+
+#Get clean environment
+wget https://raw.githubusercontent.com/aiwell-ac5000/ac5000/main/environment
+mv environment /etc/environment
+
+#sette hostname
+A=$(getenv HOST_MAC | cut -d'=' -f2 | cut -d':' -f1)
+
+if [ "$A" -eq 0 ]; then
+  A=18
+  B=83
+  C=C4
+  D=AC
+  E=50
+  F=00
+else
+  B=$(getenv HOST_MAC | cut -d'=' -f2 | cut -d':' -f2)
+  C=$(getenv HOST_MAC | cut -d'=' -f2 | cut -d':' -f3)
+  D=$(getenv HOST_MAC | cut -d'=' -f2 | cut -d':' -f4)
+  E=$(getenv HOST_MAC | cut -d'=' -f2 | cut -d':' -f5)
+  F=$(getenv HOST_MAC | cut -d'=' -f2 | cut -d':' -f6)  
+fi
+host=ac5000$A$B$C$D$E$F
+echo $host
+
+touch /etc/network/if-up.d/macchange
+echo "#!/bin/sh" > /etc/network/if-up.d/macchange
+echo 'if [ "$IFACE" = lo ]; then' >> /etc/network/if-up.d/macchange
+echo 'exit 0' >> /etc/network/if-up.d/macchange
+echo 'fi' >> /etc/network/if-up.d/macchange
+echo "/usr/bin/macchanger -m $A:$B:$C:$D:$E:$F eth0" >> /etc/network/if-up.d/macchange
+echo "/usr/bin/macchanger -m $A:$B:$C:$D:$E:$F eth1" >> /etc/network/if-up.d/macchange
+echo "getenv > /root/pipes/env" >> /etc/network/if-up.d/macchange
+chmod 755 /etc/network/if-up.d/macchange
+
+V=$(uname -r)
+ARCH = $(uname -m)
+DEBIAN_VERSION=$(grep "^VERSION=" /etc/os-release | cut -d '"' -f 2)
+echo "configure system description 'Aiwell AC5000 Debian $DEBIAN_VERSION Linux $V $ARCH'" > /etc/lldpd.conf
+systemctl restart lldpd
+systemctl enable lldpd
+
+getenv > /root/pipes/env
+
+systemctl stop ENV.service
+systemctl disable ENV.service
+rm /etc/systemd/system/ENV.service
+rm /root/pipes/ENV.sh
+
+rm logo.png*
+
+wget https://raw.githubusercontent.com/aiwell-ac5000/ac5000/main/rsyslog
+wget https://raw.githubusercontent.com/aiwell-ac5000/ac5000/main/logo.png
+cp logo.png /home/user/
+
+mv rsyslog /etc/logrotate.d/rsyslog
+
+rm /var/log/*.gz
+rm /var/log/*.[1-9]
+
+wget https://raw.githubusercontent.com/aiwell-ac5000/ac5000/main/dhcpcd.exit-hook
+mv dhcpcd.exit-hook /etc/dhcpcd.exit-hook
+
+ip addr list eth0 |grep "inet " |cut -d' ' -f6|cut -d/ -f1 > /root/pipes/ip
+
+systemctl daemon-reload
+timeout 20 service dhcpcd restart
+
+wget https://raw.githubusercontent.com/aiwell-ac5000/ac5000/main/network_recovery.sh
+chmod +x network_recovery.sh
+mv network_recovery.sh /usr/local/bin/network_recovery.sh
+(crontab -l | grep -Fq "/usr/local/bin/network_recovery.sh") || (crontab -l; echo "*/30 * * * * /usr/local/bin/network_recovery.sh") | crontab -
+
+tee /etc/logrotate.d/network_recovery > /dev/null <<EOF
+/var/log/network_recovery.log
+{
+        rotate 0
+        maxsize 2M
+        hourly
+        missingok
+        notifempty
+        delaycompress
+        compress
+}
+EOF
+
+cd /etc
+touch udev/rules.d/99-eth-mac.rules
+echo 'SUBSYSTEM=="net", ACTION=="add", ATTRS{idVendor}=="0424", ATTRS{idProduct}=="9514", KERNELS=="1-1.1", KERNEL=="eth*", NAME="eth0"' > udev/rules.d/99-eth-mac.rules
+echo 'SUBSYSTEM=="net", ACTION=="add", ATTRS{idVendor}=="0424", ATTRS{idProduct}=="9514", KERNELS=="1-1.2", KERNEL=="eth*", NAME="eth1" RUN+="/sbin/ip link set dev eth1 address AC:50:00:AC:50:00"' >> udev/rules.d/99-eth-mac.rules
+
+raspi-config nonint do_hostname $host 
+
+echo "#!/bin/bash" > /home/user/boot.sh
+echo "echo AiwellAC5000 | sudo -S raspi-config nonint do_boot_behaviour B2" >> /home/user/boot.sh
+chmod 777 /home/user/boot.sh
+usermod -aG sudo user
+
+touch /etc/systemd/system/do_boot_behaviour.service
+echo "[Unit]" > /etc/systemd/system/do_boot_behaviour.service
+echo "Description=Set boot behaviour" >> /etc/systemd/system/do_boot_behaviour.service
+echo "After=multi-user.target" >> /etc/systemd/system/do_boot_behaviour.service
+echo "" >> /etc/systemd/system/do_boot_behaviour.service
+echo "[Service]" >> /etc/systemd/system/do_boot_behaviour.service
+echo "Type=oneshot" >> /etc/systemd/system/do_boot_behaviour.service
+echo "User=user" >> /etc/systemd/system/do_boot_behaviour.service
+echo "ExecStart=/home/user/boot.sh" >> /etc/systemd/system/do_boot_behaviour.service
+echo "WorkingDirectory=/home/user" >> /etc/systemd/system/do_boot_behaviour.service
+echo "" >> /etc/systemd/system/do_boot_behaviour.service
+echo "[Install]" >> /etc/systemd/system/do_boot_behaviour.service
+echo "WantedBy=multi-user.target" >> /etc/systemd/system/do_boot_behaviour.service
+
+systemctl start do_boot_behaviour.service
+apt autoremove -y
+reboot

--- a/network_recovery.sh
+++ b/network_recovery.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+# Variables
+LOG_FILE="/var/log/syslog"
+MARKER_FILE="/var/log/network_recovery_marker"
+LOCK_FILE="/var/run/network_recovery.lock"
+NETWORK_LOG="/var/log/network_recovery.log"
+ERROR_MSGS=("smsc95xx.*Error reading MII_ACCESS" \
+            "smsc95xx.*Failed to read MII_BMSR" \
+            "smsc95xx.*Failed to read reg index.*" \
+            "dwc2.*Channel .* ChHltd set, but reason is unknown" \
+            "dwc2.*dwc2_update_urb_state_abn.*trimming xfer length")
+PING_HOSTS=("8.8.8.8" "81.167.40.222")
+LOG_ACTIONS="/var/log/network_recovery.log"
+
+# Log a message
+log_action() {
+    echo "$(date): $1" >> $LOG_ACTIONS
+}
+
+# Ensure only one instance of the script runs at a time
+ensure_single_instance() {
+    if [[ -f $LOCK_FILE ]]; then
+        log_action "Script is already running. Exiting."
+        exit 1
+    fi
+    trap "rm -f $LOCK_FILE" EXIT
+    touch $LOCK_FILE
+}
+
+# Check if the syslog file is empty and trigger rsyslog reload if needed
+check_and_reload_rsyslog() {
+    if [[ ! -s $LOG_FILE ]]; then
+        log_action "Syslog file is empty. Sending HUP signal to rsyslog."
+        sudo pkill -HUP rsyslog
+        log_action "Waiting 10 seconds for rsyslog to reset."
+        sleep 10
+    fi
+}
+
+# Get new log entries since the last marker
+get_new_logs() {
+    if [[ -f $MARKER_FILE ]]; then
+        LAST_POS=$(cat "$MARKER_FILE")
+    else
+        LAST_POS=0
+    fi
+
+    # Extract new log entries since last processed position
+    NEW_LOGS=$(tail -n +"$((LAST_POS + 1))" "$LOG_FILE")
+    echo "$NEW_LOGS"
+}
+
+# Update the marker file with the current end of the log file
+update_marker() {
+    tail -n 0 "$LOG_FILE" > /dev/null
+    echo "$(wc -l < "$LOG_FILE")" > "$MARKER_FILE"
+}
+
+# Check for any of the defined error messages in the log
+check_log_errors() {
+    local new_logs="$1"
+    for msg in "${ERROR_MSGS[@]}"; do
+        if echo "$new_logs" | grep -q "$msg"; then
+            log_action "Detected error in log: $msg"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Ping test to check connectivity
+check_ping() {
+    for host in "${PING_HOSTS[@]}"; do
+        if ping -c 2 "$host" > /dev/null 2>&1; then
+            log_action "Ping to $host successful. Network seems fine."
+            return 0
+        else
+            log_action "Ping to $host failed."
+        fi
+    done
+    return 1
+}
+
+# Restart the eth1 interface
+restart_eth1() {
+    log_action "Attempting to restart eth1..."
+    if sudo ifconfig eth1 down && sudo ifconfig eth1 up; then
+        log_action "eth1 restart successful."
+    else
+        log_action "eth1 restart failed with exit code $?"
+    fi
+}
+
+# Restart the networking service
+restart_networking() {
+    log_action "Attempting to restart networking service..."
+    if sudo systemctl restart networking; then
+        log_action "Networking service restart successful."
+    else
+        log_action "Networking service restart failed with exit code $?"
+    fi
+}
+
+# Reboot the device as a last resort
+reboot_device() {
+    log_action "All recovery attempts failed. Rebooting the device..."
+    sudo shutdown -r now
+    log_action "Reboot command issued, but this line might not be executed if the system shuts down."
+}
+
+# Main Logic
+main() {
+    ensure_single_instance
+
+    # Check and reload rsyslog if syslog file is empty
+    check_and_reload_rsyslog
+
+    # Step 1: Get new log entries since the last run
+    new_logs=$(get_new_logs)
+
+    # Step 2: Check for errors in the new logs
+    if check_log_errors "$new_logs"; then
+        # Step 3: Attempt to restart eth1 and networking
+        restart_eth1
+        restart_networking
+
+        # Step 4: Wait for 60 seconds before pinging
+        log_action "Waiting 60 seconds to allow network recovery..."
+        sleep 60
+
+        # Step 5: Perform a ping test
+        if check_ping; then
+            log_action "Network recovery successful. Exiting."
+            update_marker
+            exit 0
+        else
+            log_action "Ping failed after recovery attempts."
+            reboot_device
+        fi
+    else
+        log_action "No relevant errors detected in logs."
+    fi
+
+    # Step 6: Update the marker to avoid processing the same logs again
+    update_marker
+}
+
+main

--- a/setup.sh
+++ b/setup.sh
@@ -305,6 +305,24 @@ ip addr list eth0 |grep "inet " |cut -d' ' -f6|cut -d/ -f1 > /root/pipes/ip
 systemctl daemon-reload
 timeout 20 service dhcpcd restart
 
+wget https://raw.githubusercontent.com/aiwell-ac5000/ac5000/main/network_recovery.sh
+chmod +x network_recovery.sh
+mv network_recovery.sh /usr/local/bin/network_recovery.sh
+(crontab -l | grep -Fq "/usr/local/bin/network_recovery.sh") || (crontab -l; echo "*/30 * * * * /usr/local/bin/network_recovery.sh") | crontab -
+
+tee /etc/logrotate.d/network_recovery > /dev/null <<EOF
+/var/log/network_recovery.log
+{
+        rotate 0
+        maxsize 2M
+        hourly
+        missingok
+        notifempty
+        delaycompress
+        compress
+}
+EOF
+
 #cd /etc
 #touch udev/rules.d/99-eth-mac.rules
 #echo 'SUBSYSTEM=="net", ACTION=="add", ATTRS{idVendor}=="0424", ATTRS{idProduct}=="9514", KERNELS=="1-1.1", KERNEL=="eth*", NAME="eth0"' > udev/rules.d/99-eth-mac.rules

--- a/update.sh
+++ b/update.sh
@@ -288,7 +288,7 @@ ip addr list eth0 |grep "inet " |cut -d' ' -f6|cut -d/ -f1 > /root/pipes/ip
 systemctl daemon-reload
 timeout 20 service dhcpcd restart
 
-wget https://raw.githubusercontent.com/aiwell-ac5000/ac5000/refs/heads/amrit-edits-ac5000/network_recovery.sh
+wget https://raw.githubusercontent.com/aiwell-ac5000/ac5000/main/network_recovery.sh
 chmod +x network_recovery.sh
 mv network_recovery.sh /usr/local/bin/network_recovery.sh
 (crontab -l | grep -Fq "/usr/local/bin/network_recovery.sh") || (crontab -l; echo "*/30 * * * * /usr/local/bin/network_recovery.sh") | crontab -

--- a/update.sh
+++ b/update.sh
@@ -288,6 +288,24 @@ ip addr list eth0 |grep "inet " |cut -d' ' -f6|cut -d/ -f1 > /root/pipes/ip
 systemctl daemon-reload
 timeout 20 service dhcpcd restart
 
+wget https://raw.githubusercontent.com/aiwell-ac5000/ac5000/refs/heads/amrit-edits-ac5000/network_recovery.sh
+chmod +x network_recovery.sh
+mv network_recovery.sh /usr/local/bin/network_recovery.sh
+(crontab -l | grep -Fq "/usr/local/bin/network_recovery.sh") || (crontab -l; echo "*/30 * * * * /usr/local/bin/network_recovery.sh") | crontab -
+
+/etc/logrotate.d/network_recovery > /dev/null <<EOF
+/var/log/network_recovery.log
+{
+        rotate 0
+        maxsize 2M
+        hourly
+        missingok
+        notifempty
+        delaycompress
+        compress
+}
+EOF
+
 cd /etc
 touch udev/rules.d/99-eth-mac.rules
 echo 'SUBSYSTEM=="net", ACTION=="add", ATTRS{idVendor}=="0424", ATTRS{idProduct}=="9514", KERNELS=="1-1.1", KERNEL=="eth*", NAME="eth0"' > udev/rules.d/99-eth-mac.rules

--- a/update.sh
+++ b/update.sh
@@ -293,7 +293,7 @@ chmod +x network_recovery.sh
 mv network_recovery.sh /usr/local/bin/network_recovery.sh
 (crontab -l | grep -Fq "/usr/local/bin/network_recovery.sh") || (crontab -l; echo "*/30 * * * * /usr/local/bin/network_recovery.sh") | crontab -
 
-/etc/logrotate.d/network_recovery > /dev/null <<EOF
+tee /etc/logrotate.d/network_recovery > /dev/null <<EOF
 /var/log/network_recovery.log
 {
         rotate 0


### PR DESCRIPTION
- Included network_recovery.sh file to the repository that checks for below errors in the syslog.
Mar 10 00:00:01 ac50001883C404960D kernel: [3828921.340032] smsc95xx 1-1.1:1.0 eth1: Error reading MII_ACCESS
Mar 10 00:00:01 ac50001883C404960D kernel: [3828921.340042] smsc95xx 1-1.1:1.0 eth1: MII is busy in smsc95xx_mdio_read
Mar 10 00:00:01 ac50001883C404960D kernel: [3828921.340146] smsc95xx 1-1.1:1.0 eth1: Failed to read reg index 0x00000114: -71

- Updated update.sh script to download file using wget, make it executable and move it under /usr/local/bin/network_recovery.sh

- Added cron job to run every 30 minutes

- Added a log rotation rule under /etc/logrotate.d/network_recovery